### PR TITLE
feat: add refresh token create & validate logic for spring security for secure

### DIFF
--- a/src/main/java/kr/kernel/teachme/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/kernel/teachme/common/jwt/JwtAuthenticationFilter.java
@@ -56,11 +56,20 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     ) throws IOException {
         Member member = (Member) authResult.getPrincipal();
         String token = JwtUtils.createToken(member);
+        String refreshToken = JwtUtils.createRefreshToken(member);
+
         // 쿠키 생성
         Cookie cookie = new Cookie(JwtProperties.COOKIE_NAME, token);
         cookie.setMaxAge(JwtProperties.EXPIRATION_TIME); // 쿠키의 만료시간 설정
         cookie.setPath("/"); //사용할 수 있는 경로
         response.addCookie(cookie);
+
+        Cookie refreshCookie = new Cookie(JwtProperties.REFRESH_COOKIE_NAME, refreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setMaxAge((int) (JwtProperties.REFRESH_EXPIRATION_TIME));
+        refreshCookie.setPath("/");
+        response.addCookie(refreshCookie);
+
         response.sendRedirect("/");
     }
 

--- a/src/main/java/kr/kernel/teachme/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/kr/kernel/teachme/common/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.common.jwt;
 
+import io.jsonwebtoken.*;
 import kr.kernel.teachme.domain.member.entity.Member;
 import kr.kernel.teachme.domain.member.repository.MemberRepository;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,7 +14,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
+import java.security.Key;
+import java.util.function.Function;
 
 /**
  * JWT를 이용한 인증
@@ -35,30 +37,71 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain chain
     ) throws IOException, ServletException {
-        String token = null;
+        String accessToken = null;
+        String refreshToken = null;
+
         try {
-            // cookie 에서 JWT token을 가져옵니다. (쿠키의 이름이 JwtProperties에 있는 쿠키 이름과 같은 것을 가져옴)
-            // 쿠키의 값(토큰)을 가져오고 없으면 null 반환함.
-            token = Arrays.stream(request.getCookies())
-                    .filter(cookie -> cookie.getName().equals(JwtProperties.COOKIE_NAME)).findFirst()
-                    .map(Cookie::getValue)
-                    .orElse(null);
+            Cookie[] cookies = request.getCookies();
+            if(cookies != null) {
+                for(Cookie cookie : cookies) {
+                    if(cookie.getName().equals(JwtProperties.COOKIE_NAME)) {
+                        accessToken = cookie.getValue();
+                    } else if (cookie.getName().equals(JwtProperties.REFRESH_COOKIE_NAME)) {
+                        refreshToken = cookie.getValue();
+                    }
+                }
+            }
+//            token = Arrays.stream(request.getCookies())
+//                    .filter(cookie -> cookie.getName().equals(JwtProperties.COOKIE_NAME)).findFirst()
+//                    .map(Cookie::getValue)
+//                    .orElse(null);
         } catch (Exception ignored) {
             // 아무 것도 하지 않음
         }
-        if (token != null) {
-            try {
-                // authentication을 만들어서 SecurityContext에 넣는다.
-                Authentication authentication = getUsernamePasswordAuthenticationToken(token);
+
+        try {
+            if (accessToken != null && JwtUtils.validateToken(accessToken)) {
+                Authentication authentication = getUsernamePasswordAuthenticationToken(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            } catch (Exception e) {
-                // 실패하는 경우에는 쿠키를 초기화합니다.
+            }
+        } catch (Exception e) {
+            if (refreshToken != null && JwtUtils.validateRefreshToken(refreshToken)) {
+                String userName = getUsernameFromRefreshToken(refreshToken);
+                Member member = memberRepository.findByUsername(userName);
+                String newAccessToken = JwtUtils.createToken(member);
+
+                Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                        member,
+                        null,
+                        member.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(newAuth);
+
+                Cookie newAccessTokenCookie = new Cookie(JwtProperties.COOKIE_NAME, newAccessToken);
+                newAccessTokenCookie.setPath("/");
+                newAccessTokenCookie.setMaxAge(JwtProperties.EXPIRATION_TIME);
+                response.addCookie(newAccessTokenCookie);
+            } else {
                 Cookie cookie = new Cookie(JwtProperties.COOKIE_NAME, null);
                 cookie.setMaxAge(0);
                 response.addCookie(cookie);
+                return;
             }
         }
-        chain.doFilter(request, response);
+
+//        if (token != null) {
+//            try {
+//                // authentication을 만들어서 SecurityContext에 넣는다.
+//                Authentication authentication = getUsernamePasswordAuthenticationToken(token);
+//                SecurityContextHolder.getContext().setAuthentication(authentication);
+//            } catch (Exception e) {
+//                // 실패하는 경우에는 쿠키를 초기화합니다.
+//                Cookie cookie = new Cookie(JwtProperties.COOKIE_NAME, null);
+//                cookie.setMaxAge(0);
+//                response.addCookie(cookie);
+//            }
+//        }
+      chain.doFilter(request, response);
     }
 
     /**
@@ -76,5 +119,28 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             );
         }
         return null; // 유저가 없으면 NULL
+    }
+
+    private String getUsernameFromRefreshToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    private static <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKeyResolver(new SigningKeyResolverAdapter() {
+                        @Override
+                        public Key resolveSigningKey(JwsHeader header, Claims claims) {
+                            String kid = header.getKeyId();
+                            return JwtKey.getKey(kid);
+                        }
+                    })
+                    .build()
+                    .parseClaimsJws(token);
+
+            return claimsResolver.apply(claims.getBody());
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/kr/kernel/teachme/common/jwt/JwtProperties.java
+++ b/src/main/java/kr/kernel/teachme/common/jwt/JwtProperties.java
@@ -6,4 +6,6 @@ package kr.kernel.teachme.common.jwt;
 public class JwtProperties {
     public static final int EXPIRATION_TIME = 600000; // 10분
     public static final String COOKIE_NAME = "JWT-AUTHENTICATION";
+    public static final int REFRESH_EXPIRATION_TIME = 600000 * 6 * 24 * 7;
+    public static final String REFRESH_COOKIE_NAME = "JWT-REFRESH-AUTHENTICATION";
 }

--- a/src/main/resources/static/css/lecture/detail.css
+++ b/src/main/resources/static/css/lecture/detail.css
@@ -23,11 +23,12 @@
 }
 
 .title {
-    max-width: 50%;
     word-wrap: break-word;
     overflow-wrap: break-word;
     text-align: center;
     font-weight: bolder;
+    padding-left: 25%;
+    padding-right: 25%;
 }
 
 .homepageUrl {


### PR DESCRIPTION
보안을 위해 액세스 토큰 발급과 함께 리프레시 토큰 발급 로직을 추가하였습니다.
현재는 리프레시 토큰의 유지 기한은 7일자이며,
보안을 위해 HTTP-ONLY 속성을 추가하였습니다.
액세스토큰이 만료되었을 경우, 리프레시 토큰이 있는지 여부를 판단하여 있다면 액세스 토큰을 새로 생성하여 쿠키에 저장하고,
없다면 로그아웃 되는 형식입니다.

리뷰 부탁드립니다 :)
related issue: #108 