### PR TITLE
feat: add MemberServiceTest

### DIFF
--- a/src/main/java/kr/kernel/teachme/common/config/InitializeDefaultConfig.java
+++ b/src/main/java/kr/kernel/teachme/common/config/InitializeDefaultConfig.java
@@ -24,7 +24,7 @@ public class InitializeDefaultConfig {
      */
     @Bean
     public void initializeDefaultUser() {
-       // Member member = memberService.signup("user", "user","홍길동");
+       //Member member = memberService.signup("user", "user","홍길동");
 //        noteService.saveNote(user, "테스트", "테스트입니다.");
 //        noteService.saveNote(user, "테스트2", "테스트2입니다.");
 //        noteService.saveNote(user, "테스트3", "테스트3입니다.");
@@ -36,7 +36,7 @@ public class InitializeDefaultConfig {
      */
     @Bean
     public void initializeDefaultAdmin() {
-        // memberService.signupAdmin("admin", "admin","관리자");
+       // memberService.signupAdmin("admin", "admin","관리자");
 //        noticeService.saveNotice("환영합니다.", "환영합니다 여러분");
 //        noticeService.saveNotice("노트 작성 방법 공지", "1. 회원가입\n2. 로그인\n3. 노트 작성\n4. 저장\n* 본인 외에는 게시글을 볼 수 없습니다.");
     }

--- a/src/main/java/kr/kernel/teachme/common/exception/AlreadyRegisteredMemberException.java
+++ b/src/main/java/kr/kernel/teachme/common/exception/AlreadyRegisteredMemberException.java
@@ -1,4 +1,4 @@
-package kr.kernel.teachme.domain.member;
+package kr.kernel.teachme.common.exception;
 
 /**
  * 이미 등록된 유저를 재등록하려고 할때 발생하는 Exception

--- a/src/main/java/kr/kernel/teachme/common/exception/MemberNotFoundException.java
+++ b/src/main/java/kr/kernel/teachme/common/exception/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package kr.kernel.teachme.domain.member;
+package kr.kernel.teachme.common.exception;
 
 /**
  * 유저를 찾을 수 없을 때 발생하는 Exception

--- a/src/main/java/kr/kernel/teachme/domain/member/service/MemberService.java
+++ b/src/main/java/kr/kernel/teachme/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package kr.kernel.teachme.domain.member.service;
 
-import kr.kernel.teachme.domain.member.AlreadyRegisteredMemberException;
+import kr.kernel.teachme.common.exception.AlreadyRegisteredMemberException;
+import kr.kernel.teachme.common.exception.MemberNotFoundException;
 import kr.kernel.teachme.domain.member.entity.Member;
 import kr.kernel.teachme.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -60,8 +61,13 @@ public class MemberService {
         return memberRepository.save(new Member(username, passwordEncoder.encode(password), "ROLE_ADMIN", name));
     }
 
-    public Member findByUsername(String username) {
-        return memberRepository.findByUsername(username);
+    public Member findByUsername(String username) throws MemberNotFoundException {
+        Member member = memberRepository.findByUsername(username);
+
+        if (member == null){
+            throw new MemberNotFoundException();
+        }
+        return member;
     } //유저 정보 조회
 
    @Transactional(readOnly = true)

--- a/src/test/java/kr/kernel/teachme/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/kr/kernel/teachme/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,84 @@
+package kr.kernel.teachme.domain.member.service;
+
+import kr.kernel.teachme.common.exception.AlreadyRegisteredMemberException;
+import kr.kernel.teachme.common.exception.MemberNotFoundException;
+import kr.kernel.teachme.domain.member.entity.Member;
+import kr.kernel.teachme.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Transactional
+@SpringBootTest
+public class MemberServiceTest {
+
+    @Autowired
+    public MemberService memberService;
+
+    @Autowired
+    public MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("입력받은 username,password,name으로 signup을 수행한 후, 필드 값들이 잘 입력되었는지 확인한다.")
+    void signupTest(){
+        //given
+        String username = "user1";
+        String password = "user12345678*";
+        String name = "홍길동1";
+        //then
+        Member member = memberService.signup(username,password,name);
+        //when
+        assertThat(member.getUsername()).isEqualTo("user1");
+        assertThat(member.getPassword()).startsWith("{bcrypt}");
+        assertThat(member.getName()).isEqualTo("홍길동1");
+        assertThat(member.getAuthorities()).hasSize(1);
+        assertThat(member.getAuthorities().stream().findFirst().get().getAuthority()).isEqualTo("ROLE_USER");
+        assertThat(member.isAdmin()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 가입된 username으로 회원가입을 시도할 경우 AlreadyRegisteredMemberException을 throw 한다.")
+    void signupAlreadyResisteredExceptionTest() {
+        //given
+        String username = "user";
+        String password = "user12345678*";
+        String name = "홍길동1";
+
+        //when
+        assertThrows(AlreadyRegisteredMemberException.class, ()-> memberService.signup(username,password,name));
+    }
+
+    @Test
+    @DisplayName("username으로 repository에 있는 username을 조회했을 때 username에 맞는 Member객체를 반환한다.")
+    void findByUsernameTest() {
+        //given
+        memberRepository.save(new Member("user123", "password", "ROLE_USER","홍길동"));
+        //when
+        Member member = memberService.findByUsername("user123");
+        //then
+        then(member.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("username으로 repository에 있는 username을 조회했을 때 해당하는 username이 없으면 MemberNotFoundException을 throw 한다.")
+    void findByUsername_isNotExist(){
+        //given
+        String username = "abcd123";
+
+        //then
+        assertThrows(MemberNotFoundException.class, () -> memberRepository.findByUsername(username));
+
+
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
Memberservice의 메소드들에 대한 테스트 코드르 작성했습니다. 

signupAdmin() 메소드의 경우 실제로 사용되지 않는 코드라서 테스트 코드는 작성하지 않았습니다. 

Q. findByUsername은 repository에서 JpaRepository를 extends 받아서 구현된 메소드라, MemberRepository 내에서 직접적으로 메소드에 예외처리를 하지 못한다고 생각했습니다. 그래서 findByUsername을 사용하는 Memberservice에서 따로 예외처리를 해주었는데 이 방식이 맞는 방식인지 궁금합니다. 이렇게 예외처리를 해줄 경우, findByUsername을 사용하는 모든 클래스에서 예외처리를 해야하기 때문에,, 좋은 생각 있으면 리뷰 부탁드립니다.. !!!

related issue #128  