### PR TITLE
feat: add custom annotation for logging execution time

### DIFF
--- a/src/main/java/kr/kernel/teachme/common/annotation/LogExecutionTime.java
+++ b/src/main/java/kr/kernel/teachme/common/annotation/LogExecutionTime.java
@@ -1,0 +1,43 @@
+package kr.kernel.teachme.common.annotation;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogExecutionTime {
+
+    static final Logger log = LoggerFactory.getLogger(LogExecutionTime.class);
+
+    String value() default "";
+
+    @Component
+    @org.aspectj.lang.annotation.Aspect
+    class Aspect {
+        @Around("@annotation(logExecutionTime)")
+        public Object logExecutionTime(ProceedingJoinPoint joinPoint, LogExecutionTime logExecutionTime) throws Throwable {
+            long startTime = System.currentTimeMillis();
+            Object result = joinPoint.proceed();
+            long endTime = System.currentTimeMillis();
+            long executionTime = endTime - startTime;
+
+            String methodName = joinPoint.getSignature().toShortString();
+            String description = logExecutionTime.value();
+            if (description.isEmpty()) {
+                log.info("{} 실행 시간: {}ms", methodName, executionTime);
+            } else {
+                log.info("{} - {} 실행 시간: {}ms", description, methodName, executionTime);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/main/java/kr/kernel/teachme/domain/crawler/component/FastcampusAutoCrawler.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/component/FastcampusAutoCrawler.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.component;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureDetailResponse;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureUpdateResponse;
 import kr.kernel.teachme.domain.lecture.entity.Lecture;
@@ -34,8 +35,8 @@ public class FastcampusAutoCrawler implements AutoCrawler{
 
     @Override
     @Scheduled(cron = "0 0 0/1 * * *")
+    @LogExecutionTime("패스트캠퍼스 상시 크롤링 실행")
     public void crawlLectureAutomatically() throws InterruptedException {
-        log.info("패캠 크론잡 실행");
         List<Lecture> lecturesToUpdate = fetchLecturesToUpdate();
         List<Lecture> updatedLectures = updateLectureDetails(lecturesToUpdate);
         saveUpdatedLectures(updatedLectures);

--- a/src/main/java/kr/kernel/teachme/domain/crawler/component/InflearnAutoCrawler.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/component/InflearnAutoCrawler.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.component;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.common.exception.CrawlerException;
 import kr.kernel.teachme.domain.crawler.dto.InflearnLectureDetailResponse;
 import kr.kernel.teachme.domain.lecture.entity.Lecture;
@@ -29,8 +30,8 @@ public class InflearnAutoCrawler implements AutoCrawler{
 
     @Override
     @Scheduled(cron = "0 0 0/1 * * *")
+    @LogExecutionTime("인프런 상시 크롤링 실행")
     public void crawlLectureAutomatically() throws IOException, ParseException, InterruptedException {
-        log.info("인프런 크론잡 실행");
         try {
             List<Lecture> lecturesToUpdate = fetchLecturesToUpdate();
             List<Lecture> updatedLectures = updateLectureDetails(lecturesToUpdate);

--- a/src/main/java/kr/kernel/teachme/domain/crawler/service/FastcampusLectureDetailCrawlingService.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/service/FastcampusLectureDetailCrawlingService.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.service;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureDetailResponse;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureUpdateResponse;
 import kr.kernel.teachme.domain.lecture.entity.Lecture;
@@ -33,6 +34,7 @@ public class FastcampusLectureDetailCrawlingService implements  LectureDetailCra
     String BASE_URL;
 
     @Override
+    @LogExecutionTime("패스트캠퍼스 상세 크롤링 실행")
     public void runCrawler() throws InterruptedException {
         List<Lecture> lecturesToUpdate = fetchLecturesToUpdate();
         List<Lecture> updatedLectures = updateLectureDetails(lecturesToUpdate);
@@ -101,73 +103,5 @@ public class FastcampusLectureDetailCrawlingService implements  LectureDetailCra
 
         return modelMapper;
     }
-
-//    private List<Lecture> getFastcampusDetailResponse(List<Lecture> fastcampusLectures) throws InterruptedException {
-//        List<Lecture> fastcampusLectureList = new ArrayList<>();
-//        List<Lecture> deleteLectureList = new ArrayList<>();
-//
-//        for (Lecture lecture : fastcampusLectures){
-//            String detailUrl = BASE_URL + lecture.getLectureId() + "/products";
-//            FastcampusLectureDetailResponse response = getDetailResponse(detailUrl);
-//
-//            if(response.getData().getProducts().isEmpty()) {
-//                deleteLectureList.add(lecture);
-//                continue;
-//            }
-//
-//            FastcampusLectureUpdateResponse updateResponse = convertToLectureUpdateResponse(response);
-//
-//            lecture.updateFastcampusDetailInfo(updateResponse);
-//            fastcampusLectureList.add(lecture);
-//
-//            Thread.sleep(1000);
-//            if(fastcampusLectureList.size() > 10) break;
-//        }
-//        deleteNoLectureList(deleteLectureList);
-//        return fastcampusLectureList;
-//    }
-//
-//    private void deleteNoLectureList(List<Lecture> lectureList) {
-//        lectureRepository.deleteAll(lectureList);
-//    }
-//
-//    private FastcampusLectureDetailResponse getDetailResponse(String url) {
-//        RestTemplate restTemplate = new RestTemplate();
-//        return restTemplate.getForObject(url,FastcampusLectureDetailResponse.class);
-//    }
-//
-//
-//    public void update(){
-//        if (!lectureRepository.existsByDetailUploadFlagIsFalseAndPlatform(platform)) throw new CrawlerException("업데이트 할 데이터가 없습니다.");
-//        List<Lecture> fastcampusLectures = lectureRepository.findAllByDetailUploadFlagIsFalseAndPlatform(platform);
-//        try {
-//            List<Lecture> fastcampusLectureList = getFastcampusDetailResponse(fastcampusLectures);
-//            lectureRepository.saveAll(fastcampusLectureList);
-//        }catch (InterruptedException e){
-//            throw new CrawlerException("크롤링 중 에러 발생", e);
-//        }
-//    }
-//
-//    private FastcampusLectureUpdateResponse convertToLectureUpdateResponse(FastcampusLectureDetailResponse response) {
-//        ModelMapper modelMapper = new ModelMapper();
-//
-//        Converter<String, LocalDateTime> toLocalDateTime = context -> ZonedDateTime.parse(context.getSource(), DateTimeFormatter.ISO_DATE_TIME).toLocalDateTime();
-//
-//        modelMapper.addConverter(toLocalDateTime);
-//
-//        return getFastcampusLectureUpdateResponse(response, modelMapper);
-//    }
-//
-//    private static FastcampusLectureUpdateResponse getFastcampusLectureUpdateResponse(FastcampusLectureDetailResponse response, ModelMapper modelMapper) {
-//        FastcampusLectureUpdateResponse updateResponse = modelMapper.map(response.getData().getCourse(), FastcampusLectureUpdateResponse.class);
-//
-//        if (!response.getData().getProducts().isEmpty()) {
-//            FastcampusLectureDetailResponse.Products product = response.getData().getProducts().get(0);
-//            updateResponse.setPrice(product.getListPrice());
-//            updateResponse.setDiscountPrice(product.getSalePrice());
-//        }
-//
-//        return updateResponse;
-//    }
 
 }

--- a/src/main/java/kr/kernel/teachme/domain/crawler/service/FastcampusLectureListCrawlingService.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/service/FastcampusLectureListCrawlingService.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.service;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.common.exception.CrawlerException;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureListResponse;
 import kr.kernel.teachme.domain.crawler.dto.FastcampusLectureResponse;
@@ -27,6 +28,7 @@ public class FastcampusLectureListCrawlingService implements LectureListCrawling
     private String BASE_URL;
 
     @Override
+    @LogExecutionTime("패스트캠퍼스 목록 크롤링 실행")
     public List<FastcampusLectureResponse> crawlData() {
         FastcampusLectureListResponse crawledData = fetchFastcampusData();
         try {

--- a/src/main/java/kr/kernel/teachme/domain/crawler/service/InflearnLectureDetailCrawlingService.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/service/InflearnLectureDetailCrawlingService.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.service;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.common.exception.CrawlerException;
 import kr.kernel.teachme.domain.crawler.dto.InflearnLectureDetailResponse;
 import kr.kernel.teachme.domain.lecture.entity.Lecture;
@@ -28,6 +29,7 @@ public class InflearnLectureDetailCrawlingService implements LectureDetailCrawli
 	private static final String PLATFORM = "inflearn";
 
 	@Override
+	@LogExecutionTime("인프런 상세 크롤링 실행")
 	public void runCrawler() {
 		try {
 			List<Lecture> lecturesToUpdate = fetchLecturesToUpdate();

--- a/src/main/java/kr/kernel/teachme/domain/crawler/service/InflearnLectureListCrawlingService.java
+++ b/src/main/java/kr/kernel/teachme/domain/crawler/service/InflearnLectureListCrawlingService.java
@@ -1,5 +1,6 @@
 package kr.kernel.teachme.domain.crawler.service;
 
+import kr.kernel.teachme.common.annotation.LogExecutionTime;
 import kr.kernel.teachme.common.exception.CrawlerException;
 import kr.kernel.teachme.common.util.StringUtil;
 import kr.kernel.teachme.domain.crawler.dto.InflearnLectureListResponse;
@@ -34,6 +35,7 @@ public class InflearnLectureListCrawlingService implements LectureListCrawlingSe
 
 
 	@Override
+	@LogExecutionTime("인프런 목록 크롤링 실행")
 	public List<InflearnLectureListResponse> crawlData() throws IOException {
 		Document doc = getDocument(TARGET_URL);
 		int pageNum = getPageNumFromInflearn(doc);


### PR DESCRIPTION
실행시간 측정을 위한 로깅 어노테이션을 제작하였습니다.  (@LogExecutionTIme)
해당 어노테이션은 복잡한 비즈니스 로직의 실행시간을 측정하시는데 사용하시면 됩니다. (저희 프로젝트에 경우에는 현재 크롤링 메서드에 적용되어 있습니다)
확인하시고 디버깅시나 성능 개선을 위해서 필요하실 때 사용하시면 좋을 것 같습니다.
리뷰 부탁드립니다~!

related issue: #156 

예시 로그
`[2023-11-16 11:00:14.080] [INFO ] [scheduling-1] kr.kernel.teachme.common.annotation.LogExecutionTime 인프런 상시 크롤링 실행 - InflearnAutoCrawler.crawlLectureAutomatically() 실행 시간: 1696ms`